### PR TITLE
Remove dm action (stage of dialog) from stored SR states

### DIFF
--- a/src/main/java/edu/cmu/inmind/multiuser/sara/component/UserModelComponent.java
+++ b/src/main/java/edu/cmu/inmind/multiuser/sara/component/UserModelComponent.java
@@ -17,6 +17,8 @@ import edu.cmu.inmind.multiuser.controller.session.Session;
 import edu.cmu.inmind.multiuser.sara.repo.UserModelRepository;
 import edu.cmu.inmind.multiuser.socialreasoner.control.util.Utils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -99,7 +101,11 @@ public class UserModelComponent extends PluggableComponent {
     private void handleMsgSR(BlackboardEvent event)
     {
         final SROutput srOutput = (SROutput) event.getElement();
-        userModel.updateBehaviorNetworkStates(srOutput.getStates());
+        final List<String> states = new ArrayList<>(srOutput.getStates());
+        // The social reasoner states include the current stage of the dialog. We do not want to store this
+        // across interactions as it is not expected to stay the same. Remove it from the list
+        states.remove(srOutput.getAction());
+        userModel.updateBehaviorNetworkStates(states);
         userModel.setUserFrame(srOutput.getUserFrame());
         userModel.setRapport(srOutput.getRapport());
     }

--- a/src/main/java/edu/cmu/inmind/multiuser/sara/examples/Ex15_WholePipeline.java
+++ b/src/main/java/edu/cmu/inmind/multiuser/sara/examples/Ex15_WholePipeline.java
@@ -34,7 +34,7 @@ public class Ex15_WholePipeline extends MainClass {
                         .addPlugin(NLGComponent.class, SaraCons.ID_NLG)
                         //.addPlugin(OpenFaceComponent.class, SaraCons.ID_OF)
                         //.addPlugin(R5StreamComponent.class, SaraCons.ID_R5)
-                        //.addPlugin(UserModelComponent.class, SaraCons.ID_UM)
+                        .addPlugin(UserModelComponent.class, SaraCons.ID_UM)
                         .build()
         };
 

--- a/src/main/java/edu/cmu/inmind/multiuser/sara/examples/Ex16_MasterCallsSlaves.java
+++ b/src/main/java/edu/cmu/inmind/multiuser/sara/examples/Ex16_MasterCallsSlaves.java
@@ -47,7 +47,7 @@ public class Ex16_MasterCallsSlaves extends MainClassNew {
                         .addPlugin(SocialReasonerComponent.class, SaraCons.ID_SR)
                         .addPlugin(NLGComponent.class, SaraCons.ID_NLG)
                         //.addPlugin(R5StreamComponent.class, SaraCons.ID_R5)
-                        //.addPlugin(UserModelComponent.class, SaraCons.ID_UM)
+                        .addPlugin(UserModelComponent.class, SaraCons.ID_UM)
                         .build()
         };
     }


### PR DESCRIPTION
The social reasoner states include both various conditions that have been met throughout the course of the dialog, and the current stage of the dialog. When we start a new session, we go back to the beginning of the dialog FSM so we do not want to store this in the user model.